### PR TITLE
script to uninstall pipeline helm: uninstall also failed helm release

### DIFF
--- a/scripts/pipeline_delete_helm/unpublish-unstarted-pipelines.sh
+++ b/scripts/pipeline_delete_helm/unpublish-unstarted-pipelines.sh
@@ -70,6 +70,7 @@ if [ "$dry_run" == "1" ]; then
 fi
 
 found=0
+index=1
 
 # Check if there are any deployments
 if [ -z "$deployments" ]; then
@@ -89,7 +90,8 @@ else
 
       if [ "$dry_run" == "1" ]; then
         found=1
-        echo "Unstarted deployment for pipeline: $pipeline (Helm release: $release_name, deployment: $deployment_name, namespace: $ns)"
+        echo "$index. Unstarted deployment for pipeline: $pipeline (Helm release: $release_name, deployment: $deployment_name, namespace: $ns)"
+        ((index++))
         continue
       fi
 
@@ -117,7 +119,8 @@ if [ -z "$failing_releases" ]; then
 else
   while read -r release_name; do
     if [ "$dry_run" == "1" ]; then
-      echo "Failing Helm release: $release_name (namespace: $namespace)"
+      echo "$index. Failing Helm release: $release_name (namespace: $namespace)"
+      ((index++))
       continue
     fi
 

--- a/scripts/pipeline_delete_helm/unpublish-unstarted-pipelines.sh
+++ b/scripts/pipeline_delete_helm/unpublish-unstarted-pipelines.sh
@@ -65,40 +65,68 @@ fi
 # Get all pipeline deployments
 deployments=$(kubectl get deployments -n "${namespace}" -l app=scorer -o jsonpath="{range .items[*]}{.metadata.namespace} {.metadata.name} {'replicas='}{.status.readyReplicas} {.metadata.annotations.meta\.helm\.sh\/release-name} {.metadata.labels.pipeline}{'\n'}{end}")
 
-
-# Check if there are any deployments
-if [ -z "$deployments" ]; then
-    echo "No pipeline deployments (app=scorer) found in namespace $namespace."
-    exit 0
-fi
-
 if [ "$dry_run" == "1" ]; then
   echo "Dry run mode. Only printing helm releases of failing pipelines:"
 fi
 
-# Loop through deployments and uninstall Helm releases where no replica is ready
-while read -r namespace deployment_name replicas release_name pipeline; do
+found=0
 
-  replicas=$(echo "$replicas" | cut -d '=' -f2)
+# Check if there are any deployments
+if [ -z "$deployments" ]; then
+  echo "No pipeline deployments (app=scorer) found in namespace $namespace."
+else
+  # Loop through deployments and uninstall Helm releases where no replica is ready
+  while read -r ns deployment_name replicas release_name pipeline; do
 
-  if [[ "$replicas" == 0  || -z "$replicas" ]]; then
+    replicas=$(echo "$replicas" | cut -d '=' -f2)
 
-    if [ -z "$release_name" ]; then
-        echo "Helm release name not found for pipeline: $pipeline (deployment: $deployment_name, namespace: $namespace)"
+    if [[ "$replicas" == 0  || -z "$replicas" ]]; then
+
+      if [ -z "$release_name" ]; then
+          echo "Helm release name not found for pipeline: $pipeline (deployment: $deployment_name, namespace: $ns)"
+          continue
+      fi
+
+      if [ "$dry_run" == "1" ]; then
+        found=1
+        echo "Unstarted deployment for pipeline: $pipeline (Helm release: $release_name, deployment: $deployment_name, namespace: $ns)"
         continue
-    fi
+      fi
 
+      echo "Uninstalling Helm release: $release_name for pipeline: $pipeline (deployment: $deployment_name, namespace: $ns)"
+      if helm uninstall "$release_name" -n "$ns"; then
+          echo "Successfully uninstalled Helm release: $release_name"
+      else
+          echo "Failed to uninstall Helm release: $release_name"
+      fi
+
+    fi
+  done <<< "$deployments"
+fi
+
+if [[ $found == 0 ]]; then
+  echo "No unstarted pipeline deployments found in namespace $namespace."
+fi
+
+# Obtaining helm releases in failed state. These were not successfully installed and can be incomplete.
+# Using hardcoded string "document-ai-scorer-"  is OK, because it is a name of helm chart which
+# is baked in the backend and can't be changed by admin or user.
+failing_releases=$(helm ls -n "${namespace}" --failed | grep "document-ai-scorer-" | awk '{print $1}')
+if [ -z "$failing_releases" ]; then
+  echo "No failing releases for helm chart \"document-ai-scorer\" found in namespace $namespace."
+else
+  while read -r release_name; do
     if [ "$dry_run" == "1" ]; then
-      echo "Helm release: $release_name for pipeline: $pipeline (deployment: $deployment_name, namespace: $namespace)"
+      echo "Failing Helm release: $release_name (namespace: $namespace)"
       continue
     fi
 
-    echo "Uninstalling Helm release: $release_name for pipeline: $pipeline (deployment: $deployment_name, namespace: $namespace)"
+    echo "Uninstalling Helm release: $release_name"
     if helm uninstall "$release_name" -n "$namespace"; then
         echo "Successfully uninstalled Helm release: $release_name"
     else
         echo "Failed to uninstall Helm release: $release_name"
     fi
 
-  fi
-done <<< "$deployments"
+  done <<< "$failing_releases"
+fi


### PR DESCRIPTION
### Description

Expanding script to detect also helm releases in failed state. This happens when pipeline installation is not complete. For example when user selects incorrect pod resources (request higher than limit), which fails to create Kubernetes Deployment. 

Script now performs 2 checks:
1. It checks available replicas of pipeline - in that case, pipeline installation was complete, but replica failed to start for some internal reason
2. It checks helm releases in failed state, due to above. 

### Testing

Created 2 failing pipelines:
1. With incorrect post-processor - helm install was successful, but pod did not start
2. With incorrect resources - helm install was not successful

Script printed following output in dry-run:
```
Dry run mode. Only printing helm releases of failing pipelines:
1. Unstarted deployment for pipeline: failing-post-processor (Helm release: docai-scorer-5377e4, deployment: docai-scorer-5377e4, namespace: docai-scorers)
2. Failing Helm release: docai-scorer-cdf812 (namespace: docai-scorers)
```

and in normal run:
```
Uninstalling Helm release: docai-scorer-5377e4 for pipeline: failing-post-processor (deployment: docai-scorer-5377e4, namespace: docai-scorers)
release "docai-scorer-5377e4" uninstalled
Successfully uninstalled Helm release: docai-scorer-5377e4
No unstarted pipeline deployments found in namespace docai-scorers.
Uninstalling Helm release: docai-scorer-cdf812
release "docai-scorer-cdf812" uninstalled
Successfully uninstalled Helm release: docai-scorer-cdf812
```